### PR TITLE
Spotify adapter

### DIFF
--- a/oauth2/spotify_connector.rb
+++ b/oauth2/spotify_connector.rb
@@ -1,54 +1,54 @@
 {
   title: "Spotify",
 
-   connection: {
-     fields: [
+  connection: {
+    fields: [
       { name: 'client_id', control_type: 'password', optional: false },
       { name: 'client_secret', control_type: 'password', optional: false }
-     ],
+    ],
 
-     authorization: {
-       type: "oauth2",
+    authorization: {
+      type: "oauth2",
 
-       authorization_url: lambda do |connection|
-         params = {
-           response_type: "code",
-           client_id: connection["client_id"],
-           redirect_uri: "https://www.workato.com/oauth/callback",
-           scope: "user-read-playback-state user-modify-playback-state"
-         }.to_param
-         "https://accounts.spotify.com/authorize?" + params
-       end,
-
-       acquire: lambda do |connection, auth_code|
-         response = post("https://accounts.spotify.com/api/token").
-                      payload(
-                       	grant_type: "authorization_code",
-                        code: auth_code,
-                        redirect_uri: "https://www.workato.com/oauth/callback").
-                      user(connection['client_id']).
-                      password(connection['client_secret']).
-                      request_format_www_form_urlencoded
-         [ response, nil, nil ]
-       end,
-
-       refresh_on: 401,
-
-       refresh: lambda do |connection, refresh_token|
-         post("https://accounts.spotify.com/api/token").
-           payload(
-             grant_type: "refresh_token",
-             refresh_token: refresh_token).
-           user(connection['client_id']).
-           password(connection['client_secret']).
-           request_format_www_form_urlencoded
+      authorization_url: lambda do |connection|
+        params = {
+          response_type: "code",
+          client_id: connection["client_id"],
+          redirect_uri: "https://www.workato.com/oauth/callback",
+          scope: "user-read-playback-state user-modify-playback-state"
+        }.to_param
+        "https://accounts.spotify.com/authorize?" + params
       end,
 
-       apply: lambda do |connection, access_token|
-         headers('Authorization': "Bearer #{access_token}")
-       end
-     }
-   },
+      acquire: lambda do |connection, auth_code|
+        response = post("https://accounts.spotify.com/api/token").
+        payload(
+          grant_type: "authorization_code",
+          code: auth_code,
+          redirect_uri: "https://www.workato.com/oauth/callback").
+          user(connection['client_id']).
+          password(connection['client_secret']).
+          request_format_www_form_urlencoded
+          [ response, nil, nil ]
+      end,
+
+      refresh_on: 401,
+
+      refresh: lambda do |connection, refresh_token|
+        post("https://accounts.spotify.com/api/token").
+        payload(
+          grant_type: "refresh_token",
+          refresh_token: refresh_token).
+          user(connection['client_id']).
+          password(connection['client_secret']).
+          request_format_www_form_urlencoded
+      end,
+
+      apply: lambda do |connection, access_token|
+        headers('Authorization': "Bearer #{access_token}")
+      end
+    }
+  },
 
   object_definitions: {
     device: {
@@ -72,24 +72,20 @@
           { name: "album_type" },
           { name: "href", type: "string", control_type: "url" },
           { name: "uri", label: "Spotify URI" },
-          {
-            name: "artists", type: "array", of: "object",
+          { name: "artists", type: "array", of: "object",
             properties: [
               { name: "id" },
               { name: "name" },
               { name: "uri", label: "Spotify URI" },
               { name: "external_urls" },
               { name: "href", type: "string", control_type: "url" }
-            ]
-          },
-          {
-            name: "images", type: "array", of: "object",
+            ] },
+          { name: "images", type: "array", of: "object",
             properties: [
               { name: "url", type: "string", control_type: "url" },
               { name: "height", type: "integer" },
               { name: "width", type: "integer" }
-            ]
-          },
+            ] },
           { name: "available_markets", type: "array", properties: [] },
           { name: "external_urls" }
         ]
@@ -113,26 +109,22 @@
         [
           { name: "id" },
           { name: "name" },
-          {
-            name: "owner", type: "object", properties: [
+          { name: "owner", type: "object", properties: [
               { name: "id" },
               { name: "name" },
               { name: "uri", label: "Spotify URI" },
               { name: "external_urls" },
               { name: "href", type: "string", control_type: "url" }
-            ]
-          },
+            ] },
           { name: "uri", label: "Spotify URI" },
           { name: "external_urls" },
           { name: "href", type: "string", control_type: "url" },
           { name: "collaborative", type: "boolean" },
           { name: "public", type: "boolean" },
-          {
-            name: "tracks", type: "object", properties: [
+          { name: "tracks", type: "object", properties: [
               { name: "href", type: "string", control_type: "url" },
               { name: "total", type: "integer" }
-            ]
-          }
+            ] }
         ]
       end
     },
@@ -150,16 +142,14 @@
           { name: "is_playable", type: "boolean", label: "Playable" },
           { name: "href", type: "string", control_type: "url" },
           { name: "preview_url", type: "string", control_type: "url" },
-          {
-            name: "artists", type: "array", of: "object",
+          { name: "artists", type: "array", of: "object",
             properties: [
               { name: "id" },
               { name: "name" },
               { name: "uri", label: "Spotify URI" },
               { name: "external_urls" },
               { name: "href", type: "string", control_type: "url" }
-            ]
-          },
+            ] },
           { name: "uri", label: "Spotify URI" }
         ]
       end
@@ -173,7 +163,7 @@
   actions: {
     search_tracks: {
       description: "Search <span class=\"provider\">Tracks</span> in "\
-                   "<span class=\"provider\">Spotify</span>",
+                    "<span class=\"provider\">Spotify</span>",
 
       input_fields: lambda do
         [
@@ -208,7 +198,7 @@
 
     search_playlists: {
       description: "Search <span class=\"provider\">Playlists</span> in "\
-                   "<span class=\"provider\">Spotify</span>",
+                    "<span class=\"provider\">Spotify</span>",
 
       input_fields: lambda do
         [
@@ -243,7 +233,7 @@
 
     search_artists: {
       description: "Search <span class=\"provider\">Artists</span> in "\
-                   "<span class=\"provider\">Spotify</span>",
+                    "<span class=\"provider\">Spotify</span>",
 
       input_fields: lambda do
         [
@@ -278,7 +268,7 @@
 
     search_albums: {
       description: "Search <span class=\"provider\">Albums</span> in "\
-                   "<span class=\"provider\">Spotify</span>",
+                    "<span class=\"provider\">Spotify</span>",
 
       input_fields: lambda do
         [
@@ -313,7 +303,7 @@
 
     get_new_releases: {
       description: "Get list of <span class=\"provider\">New Releases</span> in "\
-                   "<span class=\"provider\">Spotify</span>",
+                    "<span class=\"provider\">Spotify</span>",
 
       input_fields: lambda do
         [
@@ -330,7 +320,7 @@
           input["country"] = input["country"].to_country_alpha2
         end
         get("https://api.spotify.com/v1/browse/new-releases", input).
-        params( limit: 50 )
+          params( limit: 50 )
       end,
 
       output_fields: lambda do |object_definitions|
@@ -344,7 +334,7 @@
 
       execute: lambda do |connection, input|
         get("https://api.spotify.com/v1/me/player/devices").
-        params( limit: 50 )
+          params( limit: 50 )
       end,
 
       output_fields: lambda do |object_definitions|
@@ -361,7 +351,7 @@
 
     start_resume_playback: {
       description: "Start/Resume <span class=\"provider\">Playback</span> in "\
-                   "<span class=\"provider\">Spotify</span>",
+                    "<span class=\"provider\">Spotify</span>",
 
       input_fields: lambda do
         [
@@ -370,7 +360,7 @@
             optional: true,
             sticky: true,
             hint: "Spotify URI of the context to play, "\
-                  "e.g. albums, artists or playlists."
+            "e.g. albums, artists or playlists."
           },
           {
             name: "device_id", label: "Device", optional: true, sticky: true,
@@ -388,7 +378,6 @@
           end
         end
         input = input.reject{ |k,v| k == "play_uri" }
-
         put("https://api.spotify.com/v1/me/player/play", input)
       end,
 
@@ -398,7 +387,7 @@
 
     pause_playback: {
       description: "Pause <span class=\"provider\">Playback</span> in "\
-                   "<span class=\"provider\">Spotify</span>",
+                    "<span class=\"provider\">Spotify</span>",
 
       input_fields: lambda do
         [
@@ -419,7 +408,7 @@
 
     skip_track: {
       description: "Skip to <span class=\"provider\">next track</span> in "\
-                   "<span class=\"provider\">Spotify</span>",
+                    "<span class=\"provider\">Spotify</span>",
 
       input_fields: lambda do
         [
@@ -440,7 +429,7 @@
 
     rewind_track: {
       description: "Rewind to <span class=\"provider\">previous track</span> "\
-                   "in <span class=\"provider\">Spotify</span>",
+                    "in <span class=\"provider\">Spotify</span>",
 
       input_fields: lambda do
         [
@@ -458,14 +447,15 @@
       output_fields: lambda do
       end
     },
+  },
 
   triggers: {
   },
-
+  
   pick_lists: {
     devices: lambda do |connection|
       get("https://api.spotify.com/v1/me/player/devices")["devices"].
-        map { |device| [device["name"], device["id"]] }
+      map { |device| [device["name"], device["id"]] }
     end
   }
 }

--- a/oauth2/spotify_connector.rb
+++ b/oauth2/spotify_connector.rb
@@ -22,15 +22,15 @@
 
       acquire: lambda do |connection, auth_code|
         response = post("https://accounts.spotify.com/api/token").
-                    payload(
-                      grant_type: "authorization_code",
-                      code: auth_code,
-                      redirect_uri: "https://www.workato.com/oauth/callback"
-                    ).
-                    user(connection["client_id"]).
-                    password(connection["client_secret"]).
-                    request_format_www_form_urlencoded
-        [ response, nil, nil ]
+                     payload(
+                       grant_type: "authorization_code",
+                       code: auth_code,
+                       redirect_uri: "https://www.workato.com/oauth/callback"
+                     ).
+                     user(connection["client_id"]).
+                     password(connection["client_secret"]).
+                     request_format_www_form_urlencoded
+        [response, nil, nil]
       end,
 
       refresh_on: 401,
@@ -117,7 +117,7 @@
             { name: "uri", label: "Spotify URI" },
             { name: "external_urls" },
             { name: "href", type: "string", control_type: "url" }
-          ] },
+            ] },
           { name: "uri", label: "Spotify URI" },
           { name: "external_urls" },
           { name: "href", type: "string", control_type: "url" },
@@ -126,7 +126,7 @@
           { name: "tracks", type: "object", properties: [
             { name: "href", type: "string", control_type: "url" },
             { name: "total", type: "integer" }
-          ] }
+            ] }
         ]
       end
     },

--- a/oauth2/spotify_connector.rb
+++ b/oauth2/spotify_connector.rb
@@ -3,8 +3,8 @@
 
   connection: {
     fields: [
-      { name: 'client_id', control_type: 'password', optional: false },
-      { name: 'client_secret', control_type: 'password', optional: false }
+      { name: "client_id", control_type: "password", optional: false },
+      { name: "client_secret", control_type: "password", optional: false }
     ],
 
     authorization: {

--- a/oauth2/spotify_connector.rb
+++ b/oauth2/spotify_connector.rb
@@ -35,7 +35,7 @@
 
       refresh_on: 401,
 
-      refresh: lambda do |_connection, refresh_token|
+      refresh: lambda do |connection, refresh_token|
         post("https://accounts.spotify.com/api/token").
           payload(
             grant_type: "refresh_token",

--- a/oauth2/spotify_connector.rb
+++ b/oauth2/spotify_connector.rb
@@ -383,7 +383,9 @@
           },
           {
             name: "device_id", label: "Device", optional: true, sticky: true,
-            hint: "ID of the device to play on"
+            control_type: :select, pick_list: "devices",
+            hint: "ID of the device to play on. If blank, playback will commence"\
+                  " from last active device."
           }
         ]
       end,
@@ -412,7 +414,9 @@
         [
           {
             name: "device_id", label: "Device", optional: true, sticky: true,
-            hint: "ID of the device to play on"
+            control_type: :select, pick_list: "devices",
+            hint: "ID of the device to pause on. If blank, playback will pause"\
+                  " on last active device."
           }
         ]
       end,
@@ -433,7 +437,9 @@
         [
           {
             name: "device_id", label: "Device", optional: true, sticky: true,
-            hint: "ID of the device to play on"
+            control_type: :select, pick_list: "devices",
+            hint: "ID of the device to skip on. If blank, track will be skipped"\
+                  " on last active device."
           }
         ]
       end,
@@ -450,11 +456,15 @@
       description: "Rewind to <span class=\"provider\">previous track</span> "\
                     "in <span class=\"provider\">Spotify</span>",
 
+      hint: "Rewinds to the previous track.",
+
       input_fields: lambda do
         [
           {
             name: "device_id", label: "Device", optional: true, sticky: true,
-            hint: "ID of the device to play on"
+            control_type: :select, pick_list: "devices",
+            hint: "ID of the device to rewind on. If blank, track will be rewound"\
+                  " on last active device."
           }
         ]
       end,
@@ -470,11 +480,11 @@
 
   triggers: {
   },
-  
+
   pick_lists: {
     devices: lambda do |connection|
       get("https://api.spotify.com/v1/me/player/devices")["devices"].
-      map { |device| [device["name"], device["id"]] }
+        map { |device| [device["name"], device["id"]] }
     end
   }
 }

--- a/oauth2/spotify_connector.rb
+++ b/oauth2/spotify_connector.rb
@@ -1,0 +1,471 @@
+{
+  title: "Spotify",
+
+   connection: {
+     fields: [
+      { name: 'client_id', control_type: 'password', optional: false },
+      { name: 'client_secret', control_type: 'password', optional: false }
+     ],
+
+     authorization: {
+       type: "oauth2",
+
+       authorization_url: lambda do |connection|
+         params = {
+           response_type: "code",
+           client_id: connection["client_id"],
+           redirect_uri: "https://www.workato.com/oauth/callback",
+           scope: "user-read-playback-state user-modify-playback-state"
+         }.to_param
+         "https://accounts.spotify.com/authorize?" + params
+       end,
+
+       acquire: lambda do |connection, auth_code|
+         response = post("https://accounts.spotify.com/api/token").
+                      payload(
+                       	grant_type: "authorization_code",
+                        code: auth_code,
+                        redirect_uri: "https://www.workato.com/oauth/callback").
+                      user(connection['client_id']).
+                      password(connection['client_secret']).
+                      request_format_www_form_urlencoded
+       	[ response, nil, nil ]
+       end,
+
+       refresh_on: 401,
+
+       refresh: lambda do |connection, refresh_token|
+         post("https://accounts.spotify.com/api/token").
+           payload(
+             grant_type: "refresh_token",
+             refresh_token: refresh_token).
+           user(connection['client_id']).
+           password(connection['client_secret']).
+           request_format_www_form_urlencoded
+      end,
+
+       apply: lambda do |connection, access_token|
+         headers('Authorization': "Bearer #{access_token}")
+       end
+     }
+   },
+
+  object_definitions: {
+    device: {
+      fields: lambda do
+        [
+          { name: "id" },
+          { name: "name" },
+          { name: "type" },
+          { name: "volume_percent", type: "integer" },
+          { name: "is_active", type: "boolean" },
+          { name: "is_restricted", type: "boolean" },
+        ]
+      end
+    },
+
+    album: {
+      fields: lambda do
+        [
+          { name: "id" },
+          { name: "name" },
+          { name: "album_type" },
+          { name: "href", type: "string", control_type: "url" },
+          { name: "uri", label: "Spotify URI" },
+          {
+            name: "artists", type: "array", of: "object",
+            properties: [
+              { name: "id" },
+              { name: "name" },
+              { name: "uri", label: "Spotify URI" },
+              { name: "external_urls" },
+              { name: "href", type: "string", control_type: "url" }
+            ]
+          },
+          {
+            name: "images", type: "array", of: "object",
+            properties: [
+              { name: "url", type: "string", control_type: "url" },
+              { name: "height", type: "integer" },
+              { name: "width", type: "integer" }
+            ]
+          },
+          { name: "available_markets", type: "array", properties: [] },
+          { name: "external_urls" }
+        ]
+      end
+    },
+
+    artist: {
+      fields: lambda do
+        [
+          { name: "id" },
+          { name: "name" },
+          { name: "uri", label: "Spotify URI" },
+          { name: "external_urls" },
+          { name: "href", type: "string", control_type: "url" }
+        ]
+      end
+    },
+
+    playlist: {
+      fields: lambda do
+        [
+          { name: "id" },
+          { name: "name" },
+          {
+            name: "owner", type: "object", properties: [
+              { name: "id" },
+              { name: "name" },
+              { name: "uri", label: "Spotify URI" },
+              { name: "external_urls" },
+              { name: "href", type: "string", control_type: "url" }
+            ]
+          },
+          { name: "uri", label: "Spotify URI" },
+          { name: "external_urls" },
+          { name: "href", type: "string", control_type: "url" },
+          { name: "collaborative", type: "boolean" },
+          { name: "public", type: "boolean" },
+          {
+            name: "tracks", type: "object", properties: [
+              { name: "href", type: "string", control_type: "url" },
+              { name: "total", type: "integer" }
+            ]
+          }
+        ]
+      end
+    },
+
+    track: {
+      fields: lambda do
+        [
+          { name: "id" },
+          { name: "name" },
+          { name: "duration_ms", type: "integer",
+            hint: "Track length in milliseconds" },
+          { name: "disc_number", type: "integer" },
+          { name: "track_number", type: "integer" },
+          { name: "explicit", type: "boolean" },
+          { name: "is_playable", type: "boolean", label: "Playable" },
+          { name: "href", type: "string", control_type: "url" },
+          { name: "preview_url", type: "string", control_type: "url" },
+          {
+            name: "artists", type: "array", of: "object",
+            properties: [
+              { name: "id" },
+              { name: "name" },
+              { name: "uri", label: "Spotify URI" },
+              { name: "external_urls" },
+              { name: "href", type: "string", control_type: "url" }
+            ]
+          },
+          { name: "uri", label: "Spotify URI" }
+        ]
+      end
+    }
+  },
+
+  test: lambda do |connection|
+    get("https://api.spotify.com/v1/me")
+  end,
+
+  actions: {
+    search_tracks: {
+      description: "Search <span class=\"provider\">Tracks</span> in "\
+                   "<span class=\"provider\">Spotify</span>",
+
+      input_fields: lambda do
+        [
+          {
+            name: "q",
+            label: "Keywords",
+            type: "string",
+            hint: "",
+            optional: false
+          }
+        ]
+      end,
+
+      execute: lambda do |connection, input|
+        test = get("https://api.spotify.com/v1/search", input).
+          params(
+            type: "track"
+          )["tracks"]
+      end,
+
+      output_fields: lambda do |object_definitions|
+        [
+          {
+            name: "items",
+            type: "array",
+            of: "object",
+            properties: object_definitions["track"]
+          }
+        ]
+      end
+    },
+
+    search_playlists: {
+      description: "Search <span class=\"provider\">Playlists</span> in "\
+                   "<span class=\"provider\">Spotify</span>",
+
+      input_fields: lambda do
+        [
+          {
+            name: "q",
+            label: "Keywords",
+            type: "string",
+            hint: "",
+            optional: false
+          }
+        ]
+      end,
+
+      execute: lambda do |connection, input|
+        get("https://api.spotify.com/v1/search", input).
+          params(
+            type: "playlist"
+          )["playlists"]
+      end,
+
+      output_fields: lambda do |object_definitions|
+        [
+          {
+            name: "items",
+            type: "array",
+            of: "object",
+            properties: object_definitions["playlist"]
+          }
+        ]
+      end
+    },
+
+    search_artists: {
+      description: "Search <span class=\"provider\">Artists</span> in "\
+                   "<span class=\"provider\">Spotify</span>",
+
+      input_fields: lambda do
+        [
+          {
+            name: "q",
+            label: "Keywords",
+            type: "string",
+            hint: "",
+            optional: false
+          }
+        ]
+      end,
+
+      execute: lambda do |connection, input|
+        get("https://api.spotify.com/v1/search", input).
+          params(
+            type: "artist"
+          )["artists"]
+      end,
+
+      output_fields: lambda do |object_definitions|
+        [
+          {
+            name: "items",
+            type: "array",
+            of: "object",
+            properties: object_definitions["artist"]
+          }
+        ]
+      end
+    },
+
+    search_albums: {
+      description: "Search <span class=\"provider\">Albums</span> in "\
+                   "<span class=\"provider\">Spotify</span>",
+
+      input_fields: lambda do
+        [
+          {
+            name: "q",
+            label: "Keywords",
+            type: "string",
+            hint: "",
+            optional: false
+          }
+        ]
+      end,
+
+      execute: lambda do |connection, input|
+        get("https://api.spotify.com/v1/search", input).
+          params(
+            type: "album"
+          )["albums"]
+      end,
+
+      output_fields: lambda do |object_definitions|
+        [
+          {
+            name: "items",
+            type: "array",
+            of: "object",
+            properties: object_definitions["album"]
+          }
+        ]
+      end
+    },
+
+    get_new_releases: {
+      description: "Get list of <span class=\"provider\">New Releases</span> in "\
+                   "<span class=\"provider\">Spotify</span>",
+
+      input_fields: lambda do
+        [
+          {
+            name: "country",
+            optional: true,
+            sticky: true
+          }
+        ]
+      end,
+
+      execute: lambda do |connection, input|
+        if input["country"].present?
+          input["country"] = input["country"].to_country_alpha2
+        end
+        get("https://api.spotify.com/v1/browse/new-releases", input).
+        params( limit: 50 )
+      end,
+
+      output_fields: lambda do |object_definitions|
+        object_definitions["album"]
+      end
+    },
+
+    get_devices: {
+      input_fields: lambda do
+      end,
+
+      execute: lambda do |connection, input|
+        get("https://api.spotify.com/v1/me/player/devices").
+        params( limit: 50 )
+      end,
+
+      output_fields: lambda do |object_definitions|
+        [
+          {
+            name: "devices",
+            type: "array",
+            of: "object",
+            properties: object_definitions["device"]
+          }
+        ]
+      end
+    },
+
+    start_resume_playback: {
+      description: "Start/Resume <span class=\"provider\">Playback</span> in "\
+                   "<span class=\"provider\">Spotify</span>",
+
+      input_fields: lambda do
+        [
+          {
+            name: "play_uri",
+            optional: true,
+            sticky: true,
+            hint: "Spotify URI of the context to play, "\
+                  "e.g. albums, artists or playlists."
+          },
+          {
+            name: "device_id", label: "Device", optional: true, sticky: true,
+            hint: "ID of the device to play on"
+          }
+        ]
+      end,
+
+      execute: lambda do |connection, input|
+        if input["play_uri"].present?
+          if input["play_uri"].include?("track")
+            input["uris"] = [input["play_uri"]]
+          else
+            input["context_uri"] = input["play_uri"]
+          end
+        end
+        input = input.reject{ |k,v| k == "play_uri" }
+
+        put("https://api.spotify.com/v1/me/player/play", input)
+      end,
+
+      output_fields: lambda do
+      end
+    },
+
+    pause_playback: {
+      description: "Pause <span class=\"provider\">Playback</span> in "\
+                   "<span class=\"provider\">Spotify</span>",
+
+      input_fields: lambda do
+        [
+          {
+            name: "device_id", label: "Device", optional: true, sticky: true,
+            hint: "ID of the device to play on"
+          }
+        ]
+      end,
+
+      execute: lambda do |connection, input|
+        put("https://api.spotify.com/v1/me/player/pause", input)
+      end,
+
+      output_fields: lambda do
+      end
+    },
+
+    skip_track: {
+      description: "Skip to <span class=\"provider\">next track</span> in "\
+                   "<span class=\"provider\">Spotify</span>",
+
+      input_fields: lambda do
+        [
+          {
+            name: "device_id", label: "Device", optional: true, sticky: true,
+            hint: "ID of the device to play on"
+          }
+        ]
+      end,
+
+      execute: lambda do |connection, input|
+        post("https://api.spotify.com/v1/me/player/next", input)
+      end,
+
+      output_fields: lambda do
+      end
+    },
+
+    rewind_track: {
+      description: "Rewind to <span class=\"provider\">previous track</span> "\
+                   "in <span class=\"provider\">Spotify</span>",
+
+      input_fields: lambda do
+        [
+          {
+            name: "device_id", label: "Device", optional: true, sticky: true,
+            hint: "ID of the device to play on"
+          }
+        ]
+      end,
+
+      execute: lambda do |connection, input|
+        post("https://api.spotify.com/v1/me/player/previous", input)
+      end,
+
+      output_fields: lambda do
+      end
+    },
+
+  triggers: {
+  },
+
+  pick_lists: {
+    devices: lambda do |connection|
+      get("https://api.spotify.com/v1/me/player/devices")["devices"].
+        map { |device| [device["name"], device["id"]] }
+    end
+  }
+}

--- a/oauth2/spotify_connector.rb
+++ b/oauth2/spotify_connector.rb
@@ -29,7 +29,7 @@
                       user(connection['client_id']).
                       password(connection['client_secret']).
                       request_format_www_form_urlencoded
-       	[ response, nil, nil ]
+         [ response, nil, nil ]
        end,
 
        refresh_on: 401,

--- a/oauth2/spotify_connector.rb
+++ b/oauth2/spotify_connector.rb
@@ -22,30 +22,32 @@
 
       acquire: lambda do |connection, auth_code|
         response = post("https://accounts.spotify.com/api/token").
-        payload(
-          grant_type: "authorization_code",
-          code: auth_code,
-          redirect_uri: "https://www.workato.com/oauth/callback").
-          user(connection['client_id']).
-          password(connection['client_secret']).
-          request_format_www_form_urlencoded
-          [ response, nil, nil ]
+                    payload(
+                      grant_type: "authorization_code",
+                      code: auth_code,
+                      redirect_uri: "https://www.workato.com/oauth/callback"
+                    ).
+                    user(connection["client_id"]).
+                    password(connection["client_secret"]).
+                    request_format_www_form_urlencoded
+        [ response, nil, nil ]
       end,
 
       refresh_on: 401,
 
-      refresh: lambda do |connection, refresh_token|
+      refresh: lambda do |_connection, refresh_token|
         post("https://accounts.spotify.com/api/token").
-        payload(
-          grant_type: "refresh_token",
-          refresh_token: refresh_token).
-          user(connection['client_id']).
-          password(connection['client_secret']).
+          payload(
+            grant_type: "refresh_token",
+            refresh_token: refresh_token
+          ).
+          user(connection["client_id"]).
+          password(connection["client_secret"]).
           request_format_www_form_urlencoded
       end,
 
-      apply: lambda do |connection, access_token|
-        headers('Authorization': "Bearer #{access_token}")
+      apply: lambda do |_connection, access_token|
+        headers("Authorization": "Bearer #{access_token}")
       end
     }
   },
@@ -110,21 +112,21 @@
           { name: "id" },
           { name: "name" },
           { name: "owner", type: "object", properties: [
-              { name: "id" },
-              { name: "name" },
-              { name: "uri", label: "Spotify URI" },
-              { name: "external_urls" },
-              { name: "href", type: "string", control_type: "url" }
-            ] },
+            { name: "id" },
+            { name: "name" },
+            { name: "uri", label: "Spotify URI" },
+            { name: "external_urls" },
+            { name: "href", type: "string", control_type: "url" }
+          ] },
           { name: "uri", label: "Spotify URI" },
           { name: "external_urls" },
           { name: "href", type: "string", control_type: "url" },
           { name: "collaborative", type: "boolean" },
           { name: "public", type: "boolean" },
           { name: "tracks", type: "object", properties: [
-              { name: "href", type: "string", control_type: "url" },
-              { name: "total", type: "integer" }
-            ] }
+            { name: "href", type: "string", control_type: "url" },
+            { name: "total", type: "integer" }
+          ] }
         ]
       end
     },
@@ -156,7 +158,7 @@
     }
   },
 
-  test: lambda do |connection|
+  test: lambda do |_connection|
     get("https://api.spotify.com/v1/me")
   end,
 
@@ -399,7 +401,7 @@
             input["context_uri"] = input["play_uri"]
           end
         end
-        input = input.reject { |k,v| k == "play_uri" }
+        input = input.reject { |k, _v| k == "play_uri" }
         put("https://api.spotify.com/v1/me/player/play", input)
       end,
 

--- a/oauth2/spotify_connector.rb
+++ b/oauth2/spotify_connector.rb
@@ -310,11 +310,12 @@
     },
 
     get_new_releases: {
-      description: "Get list of <span class=\"provider\">New Releases</span> in "\
-                    "<span class=\"provider\">Spotify</span>",
+      description: "Get list of <span class=\"provider\">New Releases</span> "\
+                    "in <span class=\"provider\">Spotify</span>",
 
-      hint: "Returns a list of new releases by a particular country, if provided. "\
-            "If omitted, returned items will be relevant to all countries.",
+      hint: "Returns a list of new releases by a particular country, if "\
+            "provided. If omitted, returned items will be relevant to "\
+            "all countries.",
 
       input_fields: lambda do
         [
@@ -322,7 +323,7 @@
             name: "country",
             optional: true,
             sticky: true,
-            hint: "Use ISO 3166-1 alpha-2 country code format. More information "\
+            hint: "Use ISO 3166-1 alpha-2 country code format. More information"\
                   "<a href=\"https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2\">"\
                   "here</a>."
           }
@@ -343,7 +344,7 @@
     },
 
     get_devices: {
-      description: "Get list of connected <span class=\"provider\">Devices</span> in "\
+      description: "Get list of <span class=\"provider\">Devices</span> in "\
                     "<span class=\"provider\">Spotify</span>",
 
       hint: "Returns a list of information about all connected devices.",
@@ -369,8 +370,8 @@
     },
 
     start_or_resume_playback: {
-      description: "Start or resume <span class=\"provider\">Playback</span> in "\
-                    "<span class=\"provider\">Spotify</span>",
+      description: "Start or resume <span class=\"provider\">Playback</span> "\
+                    "in <span class=\"provider\">Spotify</span>",
 
       input_fields: lambda do
         [
@@ -384,8 +385,8 @@
           {
             name: "device_id", label: "Device", optional: true, sticky: true,
             control_type: :select, pick_list: "devices",
-            hint: "ID of the device to play on. If blank, playback will commence"\
-                  " from last active device."
+            hint: "ID of the device to play on. If blank, playback will "\
+                  "commence from last active device."
           }
         ]
       end,
@@ -438,8 +439,8 @@
           {
             name: "device_id", label: "Device", optional: true, sticky: true,
             control_type: :select, pick_list: "devices",
-            hint: "ID of the device to skip on. If blank, track will be skipped"\
-                  " on last active device."
+            hint: "ID of the device to skip on. If blank, track will be "\
+                  "skipped on last active device."
           }
         ]
       end,
@@ -463,8 +464,8 @@
           {
             name: "device_id", label: "Device", optional: true, sticky: true,
             control_type: :select, pick_list: "devices",
-            hint: "ID of the device to rewind on. If blank, track will be rewound"\
-                  " on last active device."
+            hint: "ID of the device to rewind on. If blank, track will be "\
+                  "rewound on last active device."
           }
         ]
       end,

--- a/oauth2/spotify_connector.rb
+++ b/oauth2/spotify_connector.rb
@@ -334,7 +334,7 @@
           input["country"] = input["country"].to_country_alpha2
         end
         get("https://api.spotify.com/v1/browse/new-releases", input).
-          params( limit: 50 )
+          params(limit: 50)
       end,
 
       output_fields: lambda do |object_definitions|
@@ -353,7 +353,7 @@
 
       execute: lambda do |connection, input|
         get("https://api.spotify.com/v1/me/player/devices").
-          params( limit: 50 )
+          params(limit: 50)
       end,
 
       output_fields: lambda do |object_definitions|
@@ -398,7 +398,7 @@
             input["context_uri"] = input["play_uri"]
           end
         end
-        input = input.reject{ |k,v| k == "play_uri" }
+        input = input.reject { |k,v| k == "play_uri" }
         put("https://api.spotify.com/v1/me/player/play", input)
       end,
 

--- a/oauth2/spotify_connector.rb
+++ b/oauth2/spotify_connector.rb
@@ -117,7 +117,7 @@
             { name: "uri", label: "Spotify URI" },
             { name: "external_urls" },
             { name: "href", type: "string", control_type: "url" }
-            ] },
+          ] },
           { name: "uri", label: "Spotify URI" },
           { name: "external_urls" },
           { name: "href", type: "string", control_type: "url" },
@@ -126,7 +126,7 @@
           { name: "tracks", type: "object", properties: [
             { name: "href", type: "string", control_type: "url" },
             { name: "total", type: "integer" }
-            ] }
+          ] }
         ]
       end
     },

--- a/oauth2/spotify_connector.rb
+++ b/oauth2/spotify_connector.rb
@@ -179,8 +179,8 @@
         ]
       end,
 
-      execute: lambda do |connection, input|
-        test = get("https://api.spotify.com/v1/search", input).
+      execute: lambda do |_connection, input|
+        get("https://api.spotify.com/v1/search", input).
           params(
             type: "track"
           )["tracks"]
@@ -216,7 +216,7 @@
         ]
       end,
 
-      execute: lambda do |connection, input|
+      execute: lambda do |_connection, input|
         get("https://api.spotify.com/v1/search", input).
           params(
             type: "playlist"
@@ -253,7 +253,7 @@
         ]
       end,
 
-      execute: lambda do |connection, input|
+      execute: lambda do |_connection, input|
         get("https://api.spotify.com/v1/search", input).
           params(
             type: "artist"
@@ -290,7 +290,7 @@
         ]
       end,
 
-      execute: lambda do |connection, input|
+      execute: lambda do |_connection, input|
         get("https://api.spotify.com/v1/search", input).
           params(
             type: "album"
@@ -330,7 +330,7 @@
         ]
       end,
 
-      execute: lambda do |connection, input|
+      execute: lambda do |_connection, input|
         if input["country"].present?
           input["country"] = input["country"].to_country_alpha2
         end
@@ -352,7 +352,7 @@
       input_fields: lambda do
       end,
 
-      execute: lambda do |connection, input|
+      execute: lambda do |_connection, _input|
         get("https://api.spotify.com/v1/me/player/devices").
           params(limit: 50)
       end,
@@ -391,7 +391,7 @@
         ]
       end,
 
-      execute: lambda do |connection, input|
+      execute: lambda do |_connection, input|
         if input["play_uri"].present?
           if input["play_uri"].include?("track")
             input["uris"] = [input["play_uri"]]
@@ -422,7 +422,7 @@
         ]
       end,
 
-      execute: lambda do |connection, input|
+      execute: lambda do |_connection, input|
         put("https://api.spotify.com/v1/me/player/pause", input)
       end,
 
@@ -445,7 +445,7 @@
         ]
       end,
 
-      execute: lambda do |connection, input|
+      execute: lambda do |_connection, input|
         post("https://api.spotify.com/v1/me/player/next", input)
       end,
 
@@ -470,7 +470,7 @@
         ]
       end,
 
-      execute: lambda do |connection, input|
+      execute: lambda do |_connection, input|
         post("https://api.spotify.com/v1/me/player/previous", input)
       end,
 
@@ -483,7 +483,7 @@
   },
 
   pick_lists: {
-    devices: lambda do |connection|
+    devices: lambda do |_connection|
       get("https://api.spotify.com/v1/me/player/devices")["devices"].
         map { |device| [device["name"], device["id"]] }
     end

--- a/oauth2/spotify_connector.rb
+++ b/oauth2/spotify_connector.rb
@@ -165,6 +165,8 @@
       description: "Search <span class=\"provider\">Tracks</span> in "\
                     "<span class=\"provider\">Spotify</span>",
 
+      hint: "Returns a list of tracks matching the search criteria.",
+
       input_fields: lambda do
         [
           {
@@ -199,6 +201,8 @@
     search_playlists: {
       description: "Search <span class=\"provider\">Playlists</span> in "\
                     "<span class=\"provider\">Spotify</span>",
+
+      hint: "Returns a list of public playlists matching the search criteria.",
 
       input_fields: lambda do
         [
@@ -235,6 +239,8 @@
       description: "Search <span class=\"provider\">Artists</span> in "\
                     "<span class=\"provider\">Spotify</span>",
 
+      hint: "Returns a list of artists matching the search criteria.",
+
       input_fields: lambda do
         [
           {
@@ -269,6 +275,8 @@
     search_albums: {
       description: "Search <span class=\"provider\">Albums</span> in "\
                     "<span class=\"provider\">Spotify</span>",
+
+      hint: "Returns a list of albums matching the search criteria.",
 
       input_fields: lambda do
         [
@@ -305,12 +313,18 @@
       description: "Get list of <span class=\"provider\">New Releases</span> in "\
                     "<span class=\"provider\">Spotify</span>",
 
+      hint: "Returns a list of new releases by a particular country, if provided. "\
+            "If omitted, returned items will be relevant to all countries.",
+
       input_fields: lambda do
         [
           {
             name: "country",
             optional: true,
-            sticky: true
+            sticky: true,
+            hint: "Use ISO 3166-1 alpha-2 country code format. More information "\
+                  "<a href=\"https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2\">"\
+                  "here</a>."
           }
         ]
       end,
@@ -329,6 +343,11 @@
     },
 
     get_devices: {
+      description: "Get list of connected <span class=\"provider\">Devices</span> in "\
+                    "<span class=\"provider\">Spotify</span>",
+
+      hint: "Returns a list of information about all connected devices.",
+
       input_fields: lambda do
       end,
 
@@ -349,8 +368,8 @@
       end
     },
 
-    start_resume_playback: {
-      description: "Start/Resume <span class=\"provider\">Playback</span> in "\
+    start_or_resume_playback: {
+      description: "Start or resume <span class=\"provider\">Playback</span> in "\
                     "<span class=\"provider\">Spotify</span>",
 
       input_fields: lambda do


### PR DESCRIPTION
Updated `authorization` block to 

- Remove exposed secret tokens
- Add input fields for `client_id` and `client_secret` keys
- Add logic for refresh (newly introduced in Spotify API)

All other trigger/actions remain the same.